### PR TITLE
pose_follower: fixed operator precendence in comparison

### DIFF
--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -354,7 +354,7 @@ namespace pose_follower {
     transformed_plan.clear();
 
     try{
-      if (!global_plan.size() > 0)
+      if (global_plan.empty())
       {
         ROS_ERROR("Recieved plan with zero length");
         return false;


### PR DESCRIPTION
Building with clang and strict warnings enabled:

```cpp
[ 50%] Building CXX object src/pose_follower.cpp.o                                                                                                                                                        
src/pose_follower.cpp:357:11: error: logical not is only applied to the left hand side of this comparison [-Werror,-Wlogical-not-parentheses]                                      
      if (!global_plan.size() > 0)                                                                                                                                                                                                     
          ^                   ~                                                                                                                                                                                                        
src/pose_follower.cpp:357:11: note: add parentheses after the '!' to evaluate the comparison first                                                                                 
      if (!global_plan.size() > 0)                                                                                                                                                                                                     
          ^                                                                                                                                                                                                                            
           (                     )                                                                                                                                                                                                     
src/pose_follower.cpp:357:11: note: add parentheses around left hand side expression to silence this warning                                                                       
      if (!global_plan.size() > 0)                                                                                                                                                                                                     
          ^                                                                                                                                                                                                                            
          (                  )                                                                                                                                                                                                         
src/pose_follower.cpp:350:39: warning: unused parameter 'costmap' [-Wunused-parameter]                                                                                             
      const costmap_2d::Costmap2DROS& costmap, const std::string& global_frame,                                                                                                                                                        
                                      ^                                                                                                                                                                                                
1 warning and 1 error generated.
```

Functionally it was correct because `!global_plan.size()` is implicitly converted to `0` for `global_plan.size() > 0` and to `1` for `global_plan.size() == 0`.